### PR TITLE
batchGet pass param fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ class ReactNativeGoogleSheet {
         return response;
     }
 
-    async batchGet(...arg) {
+    async batchGet(arg) {
         const { dateTimeRenderOption, majorDimension, ranges = 'A:Z', valueRenderOption,  ...rest } = arg;
         const { accessToken, spreadsheetId } = this;
         const params = {


### PR DESCRIPTION
batchGet({ ranges: 'A-Z' }) call always returned 400 error because the argument object was not correctly passed.